### PR TITLE
refactor(captcha): reuse captcha instance with sync.Once

### DIFF
--- a/common/captcha/captcha.go
+++ b/common/captcha/captcha.go
@@ -1,19 +1,30 @@
 package captcha
 
-import "github.com/mojocn/base64Captcha"
+import (
+	"sync"
+
+	"github.com/mojocn/base64Captcha"
+)
 
 type Captcha struct {
 	captcha *base64Captcha.Captcha
 }
 
+var (
+	captchaOnce sync.Once
+	captcha     *Captcha
+)
+
 // 初始化验证码
 func NewCaptcha() *Captcha {
+	captchaOnce.Do(func() {
+		driver := base64Captcha.NewDriverDigit(40, 100, 4, 0.7, 1)
+		captcha = &Captcha{
+			captcha: base64Captcha.NewCaptcha(driver, &RedisStore{}),
+		}
+	})
 
-	driver := base64Captcha.NewDriverDigit(40, 100, 4, 0.7, 1)
-
-	return &Captcha{
-		captcha: base64Captcha.NewCaptcha(driver, &RedisStore{}),
-	}
+	return captcha
 }
 
 // 生成验证码

--- a/common/captcha/captcha_test.go
+++ b/common/captcha/captcha_test.go
@@ -1,0 +1,48 @@
+package captcha
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestNewCaptchaReturnsSingleton(t *testing.T) {
+	first := NewCaptcha()
+	second := NewCaptcha()
+
+	if first == nil {
+		t.Fatal("NewCaptcha() should return an initialized instance")
+	}
+
+	if first.captcha == nil {
+		t.Fatal("NewCaptcha() should initialize the underlying captcha")
+	}
+
+	if first != second {
+		t.Fatal("NewCaptcha() should return the same instance")
+	}
+}
+
+func TestNewCaptchaReturnsSingletonConcurrently(t *testing.T) {
+	const callers = 100
+
+	captchas := make(chan *Captcha, callers)
+	var waitGroup sync.WaitGroup
+	waitGroup.Add(callers)
+
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer waitGroup.Done()
+			captchas <- NewCaptcha()
+		}()
+	}
+
+	waitGroup.Wait()
+	close(captchas)
+
+	first := NewCaptcha()
+	for instance := range captchas {
+		if instance != first {
+			t.Fatal("NewCaptcha() should return the same instance to every goroutine")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

This PR refactors Captcha initialization to reuse a single `Captcha` instance throughout the application lifecycle.

Previously, every call to `captcha.NewCaptcha()` created a new `base64Captcha.Captcha` instance and a new Redis-backed store wrapper. This occurred not only when requesting a captcha image through `AuthController.CaptchaImage`, but also during login and registration captcha validation.

The Captcha driver configuration and Redis store are stateless at the application level, so repeatedly constructing these objects provides no functional benefit and adds unnecessary allocations on every request.

## Changes

- Added `sync.Once` to `common/captcha.NewCaptcha()`.
- Cached the initialized `*Captcha` instance at package scope.
- Preserved the existing `NewCaptcha()` API, so no controller or service call sites require changes.
- Ensured every caller—including captcha image generation, login, and registration validation—uses the same initialized Captcha instance.
- Added unit tests covering:
  - Returned instance is initialized.
  - Repeated calls return the same instance.
  - Concurrent calls from 100 goroutines return the same instance.

## Behavior

There is no intended API or user-facing behavior change:

- Captcha images are still generated with the existing digit driver configuration.
- Captcha codes are still stored and verified through Redis.
- Captcha verification continues to clear the code after successful verification, as before.
- Login and registration flows continue to call the same `NewCaptcha()` entry point.

The only change is that the underlying Captcha object is initialized once, safely, and reused for all subsequent requests.

## Verification

- Ran formatting and diff validation.
- Successfully compiled the captcha test package with Go 1.18 compatibility.
- Ran `go test ./common/captcha` successfully after providing the required local `application.yaml` to the package test working directory.